### PR TITLE
Make the Slack Page Less In Your Face

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 node_modules
 .DS_Store
 public/home
-
+package-lock.json
 .vercel

--- a/components/home/join-form.js
+++ b/components/home/join-form.js
@@ -1,4 +1,4 @@
-import { Card, Label, Input, Checkbox, Textarea } from 'theme-ui'
+import { Card, Label, Input, Checkbox, Heading, Textarea } from 'theme-ui'
 import useForm from '../../lib/use-form'
 import Submit from '../submit'
 
@@ -7,6 +7,23 @@ const JoinForm = ({ sx = {} }) => {
 
   return (
     <Card sx={{ maxWidth: 'narrow', mx: 'auto', ...sx }}>
+      <Heading
+          as="h1"
+          variant="title"
+          sx={{
+            mt: 0,
+            mb: [1, 2, 3],
+            fontSize: 6,
+            textAlign: 'center',
+            color: 'white',
+            lineHeight: [0.875, 0.8],
+            position: 'relative',
+            zIndex: 1,
+            textShadow: 'text'
+          }}
+      >
+        Join our Slack
+      </Heading>
       <form {...formProps}>
         <Label>
           Full name

--- a/pages/slack.js
+++ b/pages/slack.js
@@ -34,7 +34,7 @@ export default () => (
       as="header"
       sx={{
         bg: 'dark',
-        pt: [5, 6],
+        pt: [5],
         display: 'flex',
         flexDirection: 'column',
         backgroundImage:
@@ -45,29 +45,6 @@ export default () => (
       }}
     >
       <Container pt={[3, 4]} pb={[5, 6]}>
-        <Announcement
-          copy="Already have an account?"
-          href="https://hackclub.slack.com"
-          iconRight="door-enter"
-          color="red"
-        />
-        <Heading
-          as="h1"
-          variant="title"
-          sx={{
-            mt: 0,
-            mb: [3, 4, 5],
-            fontSize: [6, 8, 9],
-            textAlign: 'center',
-            color: 'white',
-            lineHeight: [0.875, 0.8],
-            position: 'relative',
-            zIndex: 1,
-            textShadow: 'text'
-          }}
-        >
-          Hack Club Slack
-        </Heading>
         <SlideUp>
           <JoinForm sx={{ variant: 'cards.translucent' }} />
         </SlideUp>


### PR DESCRIPTION
When I was changing the Slack wording on summer site I clicked on this link and I felt a bit overloaded with the huge title. this pr makes the page more simple. I don't think this design is perfect though, for instance the white colour isn't the best to use so open to feedback