### PR TITLE
Changed z index of "Join Slack Box"

### DIFF
--- a/components/slack/header.js
+++ b/components/slack/header.js
@@ -64,7 +64,7 @@ const Cover = () => (
       right: 0,
       backgroundImage: t => t.util.gx('cyan', 'purple'),
       opacity: 0.625,
-      zIndex: 0
+      zIndex: 1
     }}
   />
 )


### PR DESCRIPTION
A recent update to how css behaves in webkit stopped the join slack form from working on firefox because it was greyed out. This pr fixed it by adding an z-index:1 to the animation.