### PR TITLE
#us-politics -> #politics

### DIFF
--- a/components/slack/slack-events.js
+++ b/components/slack/slack-events.js
@@ -27,7 +27,7 @@ const whitelistedChannels = new Set(
   homelab hours hq india javascript languages late-night-hw-club lgbtq linux lounge
   mason math memes minecraft music neuroscience photography python
   rust scrapbook ship sink-my-ship sleep social studycorner support swift todayilearned
-  us-politics welcome westborough wip workshops writing
+  politics welcome westborough wip workshops writing
 `
     .split(/\s+/gi)
     .filter(i => i.length > 0)


### PR DESCRIPTION
Not sure how it works, but looks like Slack has a fallback that made "us-politics" show up. 

https://hackclub.slack.com/archives/C0C78SG9L/p1605487775139100