### PR TITLE
remove workshop bounty section from front page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -453,27 +453,6 @@ const Page = () => (
             />
           </Feature>
           <Feature
-            name="Workshop Bounty Program"
-            desc={
-              <>
-                <Highlight>
-                  Get paid $200{' '}
-                  <a href="https://workshops.hackclub.com/workshop-bounty">
-                    for submitting curriculum
-                  </a>
-                </Highlight>{' '}
-                you make for your club for every club to use. Fund your club, or
-                have fun with your bounties.
-              </>
-            }
-          >
-            <Image
-              src="https://cloud-7p08n03ez.vercel.app/2020-09-09_4kmbqakaxvjax13rzwhfq6qutzvyxn34.jpeg"
-              alt="Wanted poster for $200"
-              width={180}
-            />
-          </Feature>
-          <Feature
             icon="slack-fill"
             color="#5d114c"
             name="Talk to 100s of club leaders"


### PR DESCRIPTION
[the workshop bounty program ended a while back](https://github.com/hackclub/hackclub/issues/1597); to correspond with that, this PR will remove the relevant section from the front page.

***this may need additional review!*** with this change the `Grid` tag in the "Resources This Semester" area will hold an odd number of `Feature` tags; should the final one be centered? left alone? should a `Feature` tag for something else be added in place of the removed one?