### PR TITLE
Fix icon background bug

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -45,6 +45,7 @@ const Feature = ({ icon, color, name, desc, children, ...props }) => (
       <Box
         as="span"
         sx={{
+          width: 'fit-content',
           bg: color,
           borderRadius: 18,
           lineHeight: 0,


### PR DESCRIPTION
Hello!

I noticed a small detail which I find has the possibility of being an unintentional UI bug. Take a look at the screenshot below, from the "Existing clubs welcome." section:

![image](https://user-images.githubusercontent.com/47273556/121282672-7edaef80-c90c-11eb-8bd2-ad63b6917ed4.png)

I don't think that the background should stretch the entire width of the component, but rather to about the width of the icon.

Taking a look at the source code, I noticed that this section is a `Feature` component. Adding a `fit-content` as the width to the `Box` element for the icons appeared to have fixed the issue, and I don't see anything else breaking just yet, but I _am_ quite inexperienced with this. If there's a better solution, do suggest and proceed with that!

Here's the section corrected with this change:

![image](https://user-images.githubusercontent.com/47273556/121283779-46d4ac00-c90e-11eb-926f-aedff6d06ce0.png)

Thank you! 🙌 