### PR TITLE
Improve footer icon titles

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -36,12 +36,12 @@ const Logo = props => (
   </svg>
 )
 
-const Service = ({ href, icon, ...props }) => (
+const Service = ({ href, icon, name = "", ...props }) => (
   <Link
     target="_blank"
     rel="noopener"
     href={href}
-    title={`Hack Club on ${icon}`}
+    title={`Hack Club on ${name ? name : icon}`}
     children={<Icon glyph={icon} />}
     {...props}
   />
@@ -124,21 +124,24 @@ const Footer = ({ dark = false, children, ...props }) => (
               }
             }}
           >
-            <Service href="/slack" icon="slack-fill" target="_self" />
-            <Service href="https://twitter.com/hackclub" icon="twitter" />
-            <Service href="https://github.com/hackclub" icon="github" />
-            <Service href="https://figma.com/@hackclub" icon="figma" />
+            <Service href="/slack" icon="slack-fill" name="Slack" target="_self" />
+            <Service href="https://twitter.com/hackclub" icon="twitter" name="Twitter" />
+            <Service href="https://github.com/hackclub" icon="github" name="GitHub" />
+            <Service href="https://figma.com/@hackclub" icon="figma" name="Figma" />
             <Service
               href="https://www.facebook.com/Hack-Club-741805665870458"
               icon="facebook"
+              name="Facebook"
             />
             <Service
               href="https://www.youtube.com/c/HackClubHQ"
               icon="youtube"
+              name="YouTube"
             />
             <Service
               href="https://www.instagram.com/starthackclub"
               icon="instagram"
+              name="Instagram"
             />
             <Service href="mailto:team@hackclub.com" icon="email" />
           </Grid>


### PR DESCRIPTION
Hello again!

I'm really focusing on the minute details here, but I noticed that the (alt?) titles of the icons in the footer follow the name of the icon. While this isn't necessarily wrong — after all, it does have the name of the service of the icon — I think it can be improved upon. See the screenshot below, for example, where the Slack icon appears as `slack-fill`:

![current](https://user-images.githubusercontent.com/47273556/121450203-d9885000-c9cd-11eb-82dd-6e8196c4025d.jpg)

I tweaked the `Service` component by introducing a new (optional) parameter called `name` that can be used in lieu of `icon`. This resolves the issue of the Slack icon having "slack-fill" as the name, and other brand styling issues like "youtube" (Y and T should be capitalised), "github" (G and H should be capitalised), and so on.

I intentionally made `name` optional to prevent any breaking should anyone forget it in the future, so it should be at least safe to use. Notwithstanding, though, this seems like an easy solution, but may not necessarily be the best.

Here's the section corrected with this change:

![enhancement](https://user-images.githubusercontent.com/47273556/121450385-38e66000-c9ce-11eb-9ff1-ddc8b78ca3df.jpg)

Thank you (again!) 😄 
