### PR TITLE
feat: force light mode on website

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -13,4 +13,8 @@ theme.layout.copy.maxWidth = [null, null, 'copyPlus']
 
 theme.text.title.fontSize = [5, 6]
 
+/**Disable dark mode */
+theme.useColorSchemeMediaQuery = false
+theme.colors.modes = {}
+
 export default theme


### PR DESCRIPTION
Currently, the website forces dark mode if in localStorage `theme-ui-color-mode` is set to dark.

This, PR will force light mode and will remove these inconsistencies.