### PR TITLE
fix: force light mode on certian page, also adds an option to ignore light mode on certain pages

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -13,8 +13,4 @@ theme.layout.copy.maxWidth = [null, null, 'copyPlus']
 
 theme.text.title.fontSize = [5, 6]
 
-/**Disable dark mode */
-theme.useColorSchemeMediaQuery = false
-theme.colors.modes = {}
-
 export default theme

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -13,4 +13,8 @@ theme.layout.copy.maxWidth = [null, null, 'copyPlus']
 
 theme.text.title.fontSize = [5, 6]
 
+/**Disable dark mode */
+theme.useColorSchemeMediaQuery = false
+theme.colors.modes = {}
+
 export default theme

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,12 +5,25 @@ import Meta from '@hackclub/meta'
 import '@hackclub/theme/fonts/reg-bold.css'
 import theme from '../lib/theme'
 import { ThemeProvider } from 'theme-ui'
+import { useRouter } from 'next/router'
 
-const App = ({ Component, pageProps }) => (
-  <ThemeProvider theme={theme}>
-    <Meta as={Head} />
-    <Component {...pageProps} />
-  </ThemeProvider>
-)
+const App = ({ Component, pageProps }) => {
+  const router = useRouter()
+  const pathsToIgnore = ['bank']
+  const path = router.asPath.slice(1, -1) // remove `/` from start and end, i.e /bank/ => bank
+
+  if (!pathsToIgnore.includes(path)) {
+    /**Disable dark mode */
+    theme.useColorSchemeMediaQuery = false
+    theme.colors.modes = {}
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Meta as={Head} />
+      <Component {...pageProps} />
+    </ThemeProvider>
+  )
+}
 
 export default App


### PR DESCRIPTION
This Pr adds support for forcing light mode only on certain pages, i.e it will ignore it on certain pages that we want.

Any path that will be added to `pathsToIgnore` Array { in _app.js } will be ignored and will show its default dark mode!

For now the `bank` page is ignored and will render in light mode!