### PR TITLE
Remove "US-only" (hcb)

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -546,7 +546,7 @@ const Page = () => (
                 <Link href="/bank">
                   <a>Hack Club Bank</a>
                 </Link>
-                to fundraise, accept donations, buy things!
+                {' '}to fundraise, accept donations, buy things!
               </>
             }
           />

--- a/pages/index.js
+++ b/pages/index.js
@@ -542,7 +542,7 @@ const Page = () => (
             name="A nonprofit bank account"
             desc={
               <>
-                Use our 501(c)(3) status (US-only) and a club fund with{' '}
+                Use our 501(c)(3) status and a club fund with{' '}
                 <Link href="/bank">
                   <a>Hack Club Bank</a>
                 </Link>.

--- a/pages/index.js
+++ b/pages/index.js
@@ -542,11 +542,11 @@ const Page = () => (
             name="A nonprofit bank account"
             desc={
               <>
-                Use our 501(c)(3) status and a club fund with{' '}
+                Use our 501(c)(3) status and a restricted fund with{' '}
                 <Link href="/bank">
                   <a>Hack Club Bank</a>
-                </Link>.
-                Fundraise, accept donations, buy things!
+                </Link>
+                to fundraise, accept donations, buy things!
               </>
             }
           />


### PR DESCRIPTION
Bank is starting to roll out international support, so this PR removes the "US-only" part. I also made the description one sentence instead of 2 because the other descriptions are a single sentence.
Also changed "club fund" => "restricted fund" because that's what the official term is i think