### PR TITLE
Fixed card text size on the E-D job page.

### DIFF
--- a/pages/jobs/events-designer.js
+++ b/pages/jobs/events-designer.js
@@ -11,7 +11,7 @@ export default () => (
       as={Head}
       title="Events Designer"
       description="Hack Club is looking for an events designer / producer with coding skills to create events for Hack Clubbers."
-      image="https://workshop-cards.hackclub.com/Events Designer@ Hack Club.png?fontSize=185x&brand=HQ"
+      image="https://workshop-cards.hackclub.com/Events Designer@ Hack Club.png?fontSize=185px&brand=HQ"
     />
     <ForceTheme theme="light" />
     <Nav />


### PR DESCRIPTION
This PR request added 'p' so it is "px". The text before was super small. Changed it to 185PX.