### PR TITLE
Fix wide button in /fiscal-sponsorship/apply

### DIFF
--- a/pages/fiscal-sponsorship/apply/index.js
+++ b/pages/fiscal-sponsorship/apply/index.js
@@ -60,7 +60,7 @@ export default function Apply() {
                   sx={{
                     mb: 3,
                     gap: 2,
-                    display: 'flex',
+                    display: 'inline-flex',
                     alignItems: 'center',
                     color: 'muted',
                     textDecoration: 'none',


### PR DESCRIPTION
On https://hackclub.com/fiscal-sponsorship/apply/, the Back button appears to take up the entirety of it's parent container. I have changed "flex" to "inline-flex" to fix this issue in this PR.