### PR TITLE
Fix issue on main page where moonshot and blueprint cards direct to the wrong place. 

### DIFF
--- a/lib/cta.json
+++ b/lib/cta.json
@@ -11,7 +11,7 @@
         "buttonText": "JOIN",   
         "buttonColor": "rgb(50, 70, 110)",
 
-        "link": "https://hack.club/boba"
+        "link": "https://blueprint.hackclub.com/"
     },
     {
         "title": "Moonshot",
@@ -25,7 +25,7 @@
         "buttonText": "JOIN",   
         "buttonColor": "rgb(50, 70, 110)",
 
-        "link": "https://hack.club/boba"
+        "link": "https://moonshot.hackclub.com/"
     },
     {
         "title": "Midnight",


### PR DESCRIPTION
Changed the 'link' fields for Blueprint and Moonshot CTAs to point to their respective correct URLs. Instead of letting boba drops steal everyone...

<img width="2353" height="1040" alt="image" src="https://github.com/user-attachments/assets/8c926079-2e16-4eab-9d87-c96fb3969077" />
