### PR TITLE
Fix: Update URL to not redirect to /team/{url}

### DIFF
--- a/public/team.json
+++ b/public/team.json
@@ -468,7 +468,7 @@
     "bio": "Charlie is a Hack Clubber from the Greater Boston area. He joined Hack Club when he was 12 and launched his first YSWS when he was 13, Ham Club. More recently, he worked on a long-term hackathon called Apex, supported by Hack Club. He is now working for Hack Club to create more hardware YSWSs and events.",
     "slackId": "U054JRXUNG0",
     "email": "charlien",
-    "website": "crnicholson.com",
+    "website": "https://crnicholson.com",
     "avatar": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/a676e768a45c68eea74c7c3b602feae2eea22d45_screenshot_2024-11-17_at_5.22.37___pm.png"
   },
   {


### PR DESCRIPTION
Randomly found this error while browsing through the team page lol