### PR TITLE
Remove telephone exchange

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -180,7 +180,7 @@ const Footer = ({
             <Service href={`mailto:${email}`} icon="email-fill" name="Email" />
           </Grid>
           <Text my={2}>
-            <Link href="tel:1-855-625-HACK">1-855-625-HACK</Link>
+            <Link href="tel:1-855-625-4225">1-855-625-4225</Link>
             <br />
             <Text as="span" color="muted">
               (call toll-free)


### PR DESCRIPTION
https://hackclub.slack.com/archives/C0188CY57PZ/p1763125268866169

No consensus was made on a design to integrate the HACK vanity and support for international users without cluttering the UI. This pull request removes the vanity and just shows the real phone number.