### PR TITLE
[Footer] Capitalize brand guide

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -100,7 +100,7 @@ const Footer = ({
             <Link>Jobs</Link>
           </NextLink>
           <NextLink href="/brand" passHref>
-            <Link>Brand guide</Link>
+            <Link>Brand Guide</Link>
           </NextLink>
           <NextLink href="/press" passHref>
             <Link>Press Inquiries</Link>


### PR DESCRIPTION
All of the other footer items were in title case.