### PR TITLE
Remove pizza grant from the main page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -19,7 +19,6 @@ import ForceTheme from '../components/force-theme'
 import Footer from '../components/footer'
 import Stage from '../components/stage'
 import Carousel from '../components/index/carousel'
-import Pizza from '../components/index/cards/pizza'
 import Sprig from '../components/index/cards/sprig'
 import Sinerider from '../components/index/cards/sinerider'
 import SprigConsole from '../components/index/cards/sprig-console'
@@ -842,7 +841,6 @@ function Page({
               stars={stars.onboard.stargazerCount}
             />
             <Slack slackKey={slackKey} data={slackData} events={events} />
-            <Pizza />
           </Box>
         </Box>
         <Box>


### PR DESCRIPTION
The pizza grant is over, and this just links to a site saying that it's over. https://hackclub.com/pizza/ for reference.