### PR TITLE
Fix Slack users images in /AMAs

### DIFF
--- a/pages/amas/index.js
+++ b/pages/amas/index.js
@@ -172,6 +172,7 @@ const Page = ({ upcoming, past }) => (
               <Image
                 width={128}
                 height={128}
+                unoptimized={event.amaAvatar.startsWith('https://cachet.')}
                 src={event.amaAvatar}
                 alt={event.title}
               />


### PR DESCRIPTION
Fixes rendering for Slack user profile pictures by disabling the Nextjs optimization proxy for domains starting with `cachet.` (assumed to be cachet instances).