### PR TITLE
Add staff attribute to acon user profile

### DIFF
--- a/public/team.json
+++ b/public/team.json
@@ -756,6 +756,7 @@
     "department": "HQ",
     "role": "Engineering",
     "acknowledged": false,
+    "staff": true,
     "bio": "",
     "bioHackFoundation": "",
     "slackId": "U04KEK4TS72",


### PR DESCRIPTION
Introduce a new `staff` attribute to the acon user profile to indicate staff status.