### PR TITLE
fix: fix scrolling over bio tile on /team on touchscreens

### DIFF
--- a/components/bio.js
+++ b/components/bio.js
@@ -23,7 +23,7 @@ export default function Bio({ popup = true, spanTwo = false, ...props }) {
           zIndex: !popup ? 1003 : 5,
           maxHeight: '90vh',
           overflowY: 'hidden',
-          overscrollBehavior: 'contain',
+          overscrollBehavior: 'auto',
           gridColumn: !spanTwo ? null : [null, null, '1 / span 2'],
           position: 'relative'
         }}


### PR DESCRIPTION
Fixes scrolling on /team on mobile/touchscreen, caused by overscrollBehavior
Tested on mobile as well and works fine.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/36f4b814-143c-4e00-a3ff-8e4525b72a76" width="300" controls></video> | <video src="https://github.com/user-attachments/assets/6b70884b-cb2a-432f-9d98-a092afa9ee6a" width="300" controls></video> | 







