### PR TITLE
Remove Blueprint link from navigation

### DIFF
--- a/components/nav.js
+++ b/components/nav.js
@@ -148,7 +148,6 @@ const Navigation = props => (
       <Link>Toolbox</Link>
     </NextLink>
     <Link href="https://flavortown.hackclub.com/?ref=site-nav">Flavortown</Link>
-    <Link href="https://blueprint.hackclub.com/?ref=site-nav">Blueprint</Link>
     <NextLink href="/philanthropy" passHref>
       <Link>Donors</Link>
     </NextLink>


### PR DESCRIPTION
On certain tablet screen sizes, there is not enough room for the appropriate margin between navbar links to be conserved. Blueprint and Flavortown are the only programs currenty featured in this space,  but as Blueprint only has 1 more month left (Flavortown does as well but has not already been extended), my solution would be to remove blueprint, as it is already featured prominently on the homepage cards and this real estate is not vital to reserve for it

<img width="1350" height="96" alt="Screenshot 2026-02-20 at 10-43-32 A Home for High School Hackers – Hack Club" src="https://github.com/user-attachments/assets/ec6c68f7-15f0-4516-bc70-b8d5824b2b37" />
