### PR TITLE
fix(cta): Remove `<br>` from Jackpot description

### DIFF
--- a/lib/cta.json
+++ b/lib/cta.json
@@ -40,7 +40,7 @@
         "logoScale": 1,
         "stickerImage": "https://cdn.hackclub.com/019c7b7a-1faf-7420-9657-6e7e4323258d/alice_face.png",
         "stickerImageScale": 0.7,
-        "description": "Code for 65 hours and you’re invited to Las Vegas! <br> (Or enjoy prizes that YOU choose!)",
+        "description": "Code for 65 hours and you’re invited to Las Vegas! (Or enjoy prizes that YOU choose!)",
         "descriptionColor": "white",
         "buttonText": "JOIN NOW",
         "buttonColor": "#FAD10B",


### PR DESCRIPTION
"\<br\>" is showing up on the homepage of the website for the Jackpot CTA, which is being escaped and displayed as "\<br\>" instead of a line break.

In my opinion, it's better to just put the entire description in one paragraph without any manual line breaks.

This also prevents us from having to manually deal with allowing HTML, makes it safer in case we want to source CTAs externally, and reduces reliance on HTML if we want to use this data somewhere other than on a web page.