### PR TITLE
Use style prop for image borderRadius

### DIFF
--- a/pages/philanthropy/index.tsx
+++ b/pages/philanthropy/index.tsx
@@ -873,7 +873,7 @@ const Philanthropy = ({ posts = [] }) => {
                   src="/philanthropy/belle.png"
                   width="20"
                   height="20"
-                  sx={{ borderRadius: '100%' }}
+                  style={{ borderRadius: '100%' }}
                   alt="belle"
                 />
                 Belle, 17, Malaysia


### PR DESCRIPTION
Replace the non-functional `sx` prop with a standard `style` prop on the <img> in pages/philanthropy/index.tsx so the borderRadius is applied correctly to the image.