### PR TITLE
feat: Reduce animations if prefers reduced motion

### DIFF
--- a/components/index/cards/aces.tsx
+++ b/components/index/cards/aces.tsx
@@ -99,6 +99,9 @@ export default function Aces() {
                 width: [null, null, '200px', '250px'],
                 objectFit: 'cover',
                 animation: 'sway 4s ease-in-out infinite',
+                '@media (prefers-reduced-motion)': {
+                  animation: 'none'
+                },
                 maxWidth: 'none',
                 zIndex: 4
               }}

--- a/components/index/cards/blueprint.tsx
+++ b/components/index/cards/blueprint.tsx
@@ -50,6 +50,9 @@ export default function Blueprint({ stars, blueprintData }) {
             '50%': {
               transform: 'rotate(-8deg)'
             }
+          },
+          '@media (prefers-reduced-motion)': {
+            animation: 'none'
           }
         }}
       >
@@ -115,6 +118,9 @@ export default function Blueprint({ stars, blueprintData }) {
                 backgroundColor: '#a8f0ae',
                 alignItems: 'center',
                 animation: 'ping 2s cubic-bezier(0, 0, 0.2, 1) infinite',
+                '@media (prefers-reduced-motion)': {
+                  animation: 'none' // pulse is handled by the box after this box
+                },
                 '@keyframes ping': {
                   '0%': {
                     transform: 'scale(1)',
@@ -133,7 +139,18 @@ export default function Blueprint({ stars, blueprintData }) {
                 width: '100%',
                 height: '100%',
                 borderRadius: '9999px',
-                backgroundColor: '#a8f0ae'
+                backgroundColor: '#a8f0ae',
+                '@media (prefers-reduced-motion)': {
+                  animation: 'pulse 5s infinite'
+                },
+                '@keyframes pulse': {
+                  '0%': {
+                    backgroundColor: '#a8f0ae'
+                  },
+                  '50%': {
+                    backgroundColor: '#86aa89'
+                  }
+                }
               }}
             />
           </Box>

--- a/components/index/cards/flavortown.tsx
+++ b/components/index/cards/flavortown.tsx
@@ -85,7 +85,10 @@ export default function Flavortown() {
                 right: '-40px',
                 width: '250px',
                 rotate: '-15deg',
-                animation: 'breathe infinite 3.5s ease'
+                animation: 'breathe infinite 3.5s ease',
+                '@media (prefers-reduced-motion)': {
+                  animation: 'none'
+                }
               }}
             />
             <Image
@@ -97,6 +100,9 @@ export default function Flavortown() {
                 right: '80px',
                 width: '170px',
                 animation: 'breathe infinite 4s 1s ease-in-out',
+                '@media (prefers-reduced-motion)': {
+                  animation: 'none'
+                },
                 rotate: '5deg'
               }}
             />

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -183,6 +183,10 @@ const Spinning = styled(Image)`
   animation-duration: 10000ms;
   animation-iteration-count: infinite;
   animation-timing-function: linear;
+  @media (prefers-reduced-motion) {
+    animation: none;
+  }
+
   aspect-ratio: 1;
 `
 

--- a/pages/fiscal-sponsorship/index.tsx
+++ b/pages/fiscal-sponsorship/index.tsx
@@ -93,10 +93,13 @@ function MobileAppAlert() {
           alignItems: 'center',
           gap: 10,
           mt: [20, -50],
-          transform: 'scaleY(0)',
           '@media (prefers-reduced-motion: no-preference)': {
+            transform: 'scaleY(0)',
             animation: `${unfold} 0.5s ease-out forwards`,
             animationDelay: '0.5s'
+          },
+          '@media (prefers-reduced-motion: reduce)': {
+            transform: 'scaleY(100%)',
           },
           flexDirection: ['column', 'row']
         }}

--- a/pages/philanthropy/index.tsx
+++ b/pages/philanthropy/index.tsx
@@ -37,6 +37,7 @@ import InnovationCircuit from '../../public/donate/0screenshot_2021-10-03_at_3.4
 import WindyCity from '../../public/donate/6screenshot_2021-10-03_at_3.29.29_pm.png'
 import ZephyrFun from '../../public/donate/0screenshot_2021-10-03_at_3.59.34_pm.png'
 import GoldenTrain from '../../public/home/golden-train.png'
+import usePrefersMotion from '../../lib/use-prefers-motion'
 
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from 'recharts'
 
@@ -50,7 +51,7 @@ const PhotoRow = ({ photos }) => (
   <Box sx={{ height: '160px', overflow: 'hidden' }}>
     <Box sx={{ display: ['block', 'block', 'block', 'block', 'none'] }}>
       <AMarquee
-        velocity={12}
+        velocity={usePrefersMotion() ? 12 : 0}
       >
         {photos.map((photo, index) => (
           <Image
@@ -68,7 +69,7 @@ const PhotoRow = ({ photos }) => (
     </Box>
     <Box sx={{ display: ['none', 'none', 'none', 'none', 'block'] }}>
       <AMarquee
-        velocity={12}
+        velocity={usePrefersMotion() ? 12 : 0}
       >
         {photos.map((photo, index) => (
           <Image


### PR DESCRIPTION
People might not animations for various reasons (for example, vestibular disorders), so the `prefers-reduced-motion` CSS media feature should be respected.

I've reduced or toned down motion effects and animations that I found (and know how to reduce; I don't know how to deal with the card marquee and some other things), but I did figure out many of them.

Note that the fiscal sponsorship/HCB page had an announcement that wasn't showing if the user prefers reduced motion... Fixing that involved me moving `scaleY` to the `prefers-reduced-motion` blocks.