### PR TITLE
refactor: use getStaticProps for team and acknowledged instead

### DIFF
--- a/pages/acknowledged.tsx
+++ b/pages/acknowledged.tsx
@@ -96,7 +96,7 @@ export default function Acknowleged({ team }) {
   )
 }
 
-export const getServerSideProps = async () => {
+export const getStaticProps = async () => {
   try {
     const acknowledged = await fetchAcknowledged()
     return { props: { team: { acknowledged } } }

--- a/pages/philanthropy/supporters.tsx
+++ b/pages/philanthropy/supporters.tsx
@@ -1,5 +1,4 @@
 /** @jsxImportSource theme-ui */
-import { useEffect } from 'react'
 import styled from '@emotion/styled'
 import {
   Box,
@@ -98,13 +97,7 @@ const DonorListing = ({ name, url }) => {
   }
 }
 
-export default function Donate({ sprig }) {
-  useEffect(() => {
-    if (sprig) {
-      window.document.getElementById('sprig-donation').scrollIntoView()
-    }
-  }, [sprig])
-
+export default function Donate() {
   return (
     <Box>
       <Meta
@@ -229,10 +222,3 @@ export default function Donate({ sprig }) {
   )
 }
 
-export async function getServerSideProps(context) {
-  return {
-    props: {
-      sprig: Object.keys(context.query).includes('gl')
-    }
-  }
-}

--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -437,7 +437,7 @@ export default function Team({ team }) {
   )
 }
 
-export const getServerSideProps = async () => {
+export const getStaticProps = async () => {
   try {
     const current = await fetchTeam()
     return { props: { team: { current } } }


### PR DESCRIPTION
 since it has no reason to be dynamic
 
 Last blame was [here](https://github.com/hackclub/site/commit/3eddde67557827b49560350f6c8a31233597e7f7), it used an external api back then, but that's no longer the case since team.json/acknowledged.json are used instead, and the endpoint is dead as well.