### PR TITLE
Remove banner ad above welcome message

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -289,15 +289,6 @@ function Page({
             alt="Hack Clubbers gather in the great outdoors of Cabot, VT, for an experience unlike any other: Outernet. 📸 Photo by Matt Gleich, Hack Clubber in NH!"
             gradient="linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.45))"
           />
-          {announcement && (
-            <Announcement
-              width="90vw"
-              copy={announcement.copy}
-              caption={announcement.caption}
-              href={announcement.href}
-              imgSrc={announcement.imgSrc}
-            />
-          )}
           <Box
             sx={{
               width: '90vw',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -278,7 +278,7 @@ function Page({
           sx={{
             bg: 'dark',
             pt: [4, 5],
-            pb: [2, 3],
+            pb: [2, 1],
             textAlign: 'left',
             position: 'relative',
             overflowX: 'hidden'
@@ -296,6 +296,7 @@ function Page({
               position: 'relative',
               mx: 'auto',
               py: [4, 4, 4],
+              pb: 1,
               textShadow: 'text'
             }}
           >
@@ -500,9 +501,13 @@ function Page({
           <Box
             sx={{
               display: 'flex',
-              justifyContent: ['flex-start', 'flex-start', 'flex-end'],
+              position: ['relative', 'relative', 'absolute'],
+              bottom: ['0px', '0px', '24px'],
+              right: ['0px', '0px', '4px'],
+              justifyContent: ['flex-end', 'flex-end', 'flex-end'],
               marginRight: 2,
-              mt: [4, 3, 1]
+              mt: [3, 2, 0],
+              mr: [2, 3, null]
             }}
           >
             <Badge

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -277,7 +277,7 @@ function Page({
           as="header"
           sx={{
             bg: 'dark',
-            pt: [5, 6],
+            pt: [4, 5],
             pb: [2, 3],
             textAlign: 'left',
             position: 'relative',
@@ -442,7 +442,7 @@ function Page({
                 <Button
                   variant="ctaLg"
                   as="a"
-                  {...({href: "/slack"} as any)}
+                  {...({ href: "/slack" } as any)}
                   mt={[3, 0, 0]}
                   mr={3}
                   sx={{ transformOrigin: 'center left' }}
@@ -507,7 +507,7 @@ function Page({
           >
             <Badge
               as="a"
-              {...({href: "https://outernet.hackclub.com/"} as any)}
+              {...({ href: "https://outernet.hackclub.com/" } as any)}
               target="_blank"
               rel="noopener"
               variant="pill"
@@ -551,7 +551,7 @@ function Page({
                   mx: 0,
                   whiteSpace: ['wrap', 'nowrap', 'nowrap'],
                   color: 'white',
-                  background: (t: any)=> t.util.gx('red', 'orange'),
+                  background: (t: any) => t.util.gx('red', 'orange'),
                   WebkitBackgroundClip: 'text',
                   WebkitTextFillColor: 'transparent'
                 }}
@@ -1162,7 +1162,7 @@ function Page({
             >
               <Card
                 as="a"
-                {...({href: "/slack"} as any)}
+                {...({ href: "/slack" } as any)}
                 target="_blank"
                 rel="noopener"
                 variant="interactive"
@@ -1233,7 +1233,7 @@ function Page({
                   }
                 }}
                 as="a"
-                {...({href: "https://github.com/hackclub"} as any)}
+                {...({ href: "https://github.com/hackclub" } as any)}
                 variant="interactive"
                 target="_blank"
                 rel="noopener"
@@ -1287,7 +1287,7 @@ function Page({
                   }
                 }}
                 as="a"
-                {...({href: "/clubs"} as any)}
+                {...({ href: "/clubs" } as any)}
                 variant="interactive"
                 target="_blank"
                 rel="noopener"


### PR DESCRIPTION
**My Take:** I believe the bar for what content is promoted above welcoming visitors to hack club should be quite high.

### The Problem

- Right now. we have a perpetual announcement banner, which while originally a true announcement, has become a randomly-selected ad for one of 3-4 programs which are all already advertised with full card ads just below the welcome message. 
- This results in multiple ads for either stasis, FT, or Sleepover being displayed in this same top-fold section. 
- **Before Screenshots with different banner ad variations:**
  | Flavortown | Sleepover | Stasis |
  | :-- | :----------: | ---: |
  | <img width="1316" height="648" alt="image" src="https://github.com/user-attachments/assets/59ded9b2-382a-4c1d-ab49-66b740ddad71" /> | <img width="1315" height="643" alt="image" src="https://github.com/user-attachments/assets/a163286b-bf84-42e4-aca5-f6652841754d" /> | <img width="1314" height="642" alt="image" src="https://github.com/user-attachments/assets/6f7407a7-54d0-4bd4-8d31-50d44828b561" /> |


- Further, on slower networks, this announcement loads after the main page, suddenly shifting the page content 
  - I tested and on my school wifi/computer, it takes an average of 7.5 seconds for this announcement to finish loading in.
 
- Also, much of the hero (such as parts of the program cards,  the backround image's caption, and 'view more programs' button) is cut off on many common screen sizes, which isn't super professional :/

### This PR's Solution:

This PR just removes the announcement. I think this component should be reserved for actual announcements: things that visitors should see that are not prominent in the homepage (e.g. big news & Privacy Policy updates, not program ads). This is more similar to how other companies utilize their banners and combats the "ad creep" which has been affecting the homepage (see #1886, #1873, #1896 ):

**Screenshot of New Hero Section:**

<img width="1313" height="647" alt="image" src="https://github.com/user-attachments/assets/6b8f2c30-d05f-40dd-8bbe-fa04256ac8c1" />
