### PR TITLE
add kawaii logo url param

### DIFF
--- a/components/flag.tsx
+++ b/components/flag.tsx
@@ -32,8 +32,11 @@ const scrolled = props =>
     }
   `
 
-const Base = styled(Link)`
-  background-image: url(https://assets.hackclub.com/flag-orpheus-top.svg);
+const Base = styled(Link)<{ uwu?: boolean }>`
+  background-image: ${props =>
+    props.uwu
+      ? 'url(/stickers/hack-club-anime.png)'
+      : 'url(https://assets.hackclub.com/flag-orpheus-top.svg)'};
   background-repeat: no-repeat;
   background-position: top left;
   background-size: contain;

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -7,6 +7,7 @@ import Icon from './icon'
 import Flag from './flag'
 import ScrollLock from 'react-scrolllock'
 import NextLink from 'next/link'
+import { useSearchParams } from 'next/navigation'
 
 const rgbaBgColor = (props, opacity) =>
   `rgba(
@@ -178,6 +179,8 @@ export default function Header({
   const [scrolled, setScrolled] = useState(false)
   const [toggled, setToggled] = useState(false)
   const [mobile, setMobile] = useState(false)
+  const searchParams = useSearchParams(); 
+  const isKawaii = searchParams.get('uwu') != null;
 
   const onScroll = () => {
     const newState = window.scrollY >= 16
@@ -229,7 +232,10 @@ export default function Header({
       as="header"
     >
       <Content>
-        <Flag scrolled={scrolled || fixed} />
+        <Flag
+          scrolled={scrolled || fixed}
+          uwu={isKawaii}
+        />        
         <Navigation
           as="nav"
           aria-hidden={!!mobile}


### PR DESCRIPTION
Similar to the kawaii logo URL flag on projects such as [React](https://react.dev/?uwu), [Vue](https://vuejs.org/?uwu), [Elysia](https://elysiajs.com/), [Angular](https://angular.dev/?uwu=), Vite, Next.js, and more

| Hero | Scrolled |
| ------- | ------------ |
| <img width="2039" height="1490" alt="Screenshot from 2026-03-11 20-57-52" src="https://github.com/user-attachments/assets/1feee4b8-36f0-4e61-95ba-bb8d1e63b2f7" /> | <img width="2039" height="1490" alt="Screenshot from 2026-03-11 20-58-52" src="https://github.com/user-attachments/assets/26b0f542-c63b-4112-a010-e790cb16a378" /> |

Justification: Fun Easter Egg :3


