### PR TITLE
Remove extra bottom padding on welcome message

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -459,7 +459,7 @@ function Page({
                     `}</style>
                   </>
                 )} */}
-                    <Box sx={{ display: 'flex', flexWrap: ['wrap', 'wrap', 'wrap', 'nowrap'] }}>
+                    <Box sx={{ display: 'flex', pb: [1, 2, 3], flexWrap: ['wrap', 'wrap', 'wrap', 'nowrap'] }}>
                       <Button
                         variant="ctaLg"
                         as="a"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -300,8 +300,8 @@ function Page({
           <Box
             sx={{
               width: '100%',
-              maxWidth: ['100%', '100%','1500px'],
-              px:[3, 4, 4],
+              maxWidth: ['100%', '100%', '1500px'],
+              px: [3, 4, 4],
               position: 'relative',
               mx: 'auto',
               py: [4, 4, 4],
@@ -313,7 +313,7 @@ function Page({
               variant="eyebrow"
               sx={{
                 color: 'sunken',
-                pb: [3,3,5],
+                pb: 2,
                 position: 'relative',
                 display: 'block'
               }}
@@ -322,73 +322,73 @@ function Page({
               Welcome to Hack&nbsp;Club
             </Text>
             <Heading>
-              <Box sx={{ 
-                display: 'flex', 
-                flexDirection: ['column', 'column', 'column', 'row'], 
+              <Box sx={{
+                display: 'flex',
+                flexDirection: ['column', 'column', 'column', 'row'],
                 flexWrap: ['nowrap', 'nowrap', 'nowrap', 'wrap'],
-                gap: 2, 
-                alignItems:[null, null,null,'end']
-                }}>
-                <Box sx={{ flex: 1, minWidth: [null, null, null, 'min(100%, 1000px)']}}>
-                <Text
-                  as="p"
-                  variant="title"
-                  sx={{
-                    color: 'white',
-                    mb: [3, 4],
-                    zIndex: 1,
-                    textAlign: 'left',
-                    fontSize: ['42px', '52px', '58px'],
-                    lineHeight: 1.2,
-                    width: '100%'
-                  }}
-                >
-                  We are{' '}
+                gap: 2,
+                alignItems: [null, null, null, 'end']
+              }}>
+                <Box sx={{ flex: 1, minWidth: [null, null, null, 'min(100%, 1000px)'] }}>
                   <Text
+                    as="p"
+                    variant="title"
                     sx={{
-                      color: 'transparent',
-                      ml: 2,
-                      mr: 3,
-                      whiteSpace: 'nowrap',
-                      display: ['none', 'inline','inline']
+                      color: 'white',
+                      mb: [3, 4],
+                      zIndex: 1,
+                      textAlign: 'left',
+                      fontSize: ['42px', '52px', '58px'],
+                      lineHeight: 1.2,
+                      width: '100%'
                     }}
                   >
+                    We are{' '}
                     <Text
-                      onClick={() => {
-                        !reveal ? setReveal(true) : setReveal(false)
-                      }}
                       sx={{
-                        ...redBadgeSx,
-                        position: 'absolute',
-                        transform: 'rotate(-2deg) translateY(-5px)',                      
-                        textDecoration: 'none',
-                        '&:hover': {
-                          cursor: 'pointer'
-                        }
+                        color: 'transparent',
+                        ml: 2,
+                        mr: 3,
+                        whiteSpace: 'nowrap',
+                        display: ['none', 'inline', 'inline']
                       }}
-                      aria-hidden="true"
                     >
+                      <Text
+                        onClick={() => {
+                          !reveal ? setReveal(true) : setReveal(false)
+                        }}
+                        sx={{
+                          ...redBadgeSx,
+                          position: 'absolute',
+                          transform: 'rotate(-2deg) translateY(-5px)',
+                          textDecoration: 'none',
+                          '&:hover': {
+                            cursor: 'pointer'
+                          }
+                        }}
+                        aria-hidden="true"
+                      >
+                        <Comma>{slackData.total_members_count}</Comma> teen hackers
+                      </Text>
                       <Comma>{slackData.total_members_count}</Comma> teen hackers
                     </Text>
-                    <Comma>{slackData.total_members_count}</Comma> teen hackers
-                  </Text>
 
-                  <Text sx={{ ...redBadgeSx, display: ['inline-block', 'none', 'none'],transform: 'rotate(-2deg)', mx: 2 }}>
-                    teen hackers
+                    <Text sx={{ ...redBadgeSx, display: ['inline-block', 'none', 'none'], transform: 'rotate(-2deg)', mx: 2 }}>
+                      teen hackers
+                    </Text>
+
+                    <Box as="br" sx={{ display: ['inline', 'none', 'none'] }} /> from around
+                    the world who code together
                   </Text>
-                
-                  <Box as="br" sx={{ display: ['inline', 'none', 'none'] }} /> from around
-                  the world who code together
-              </Text>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: 'row',
-                  rowGap: 3,
-                  marginBottom: 3
-                }}
-              >
-                {/* {ctaVariant === 'blueprint' ? (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'row',
+                      rowGap: 3,
+                      marginBottom: 3
+                    }}
+                  >
+                    {/* {ctaVariant === 'blueprint' ? (
                   <Button
                     variant="ctaLg"
                     as="a"
@@ -459,88 +459,88 @@ function Page({
                     `}</style>
                   </>
                 )} */}
-                <Box sx={{ display: 'flex', flexWrap:['wrap', 'wrap', 'wrap', 'nowrap']}}>
-                  <Button
-                    variant="ctaLg"
-                    as="a"
-                    {...({ href: "https://slack.hackclub.com" } as any)}
-                    my={[3, 3, 0]}
-                    mr={3}
-                    sx={{ transformOrigin: 'center left', whiteSpace: 'nowrap' }}
-                  >
-                    Join Hack Club
-                  </Button>
-                  <Text
-                    variant="eyebrow"
-                    as="h4"
-                    sx={{
-                      fontSize: [2, 2, 3],
-                      maxWidth: 'layout',
-                      my: 'auto',
-                      color: 'white',
-                      textShadow:
-                        'rgba(0, 0, 0, 1) 0 0 10px, rgba(0, 0, 0, 1) 0 0 10px, rgba(0, 0, 0, 0.5) 0 0 10px'
-                    }}
-                  >
-                    Or, check out our programs:
-                  </Text>
-                </Box>
-              </Box>
-              <CTAS cards={ctaCards} />
-             
-              </Box>
-              <Box sx={{
-                position: 'relative',
-                marginLeft: [0, 0, 0, 'auto'],  
-                width: ['100%', '100%', '100%', 'auto'],
-                }}>
-                <Text 
-                as="a"
-                href="https://fallout.hackclub.com/?utm_source=cta"
-                target="_blank"
-                sx={{
-                  position: 'absolute',
-                  top: '100%',
-                  right: 0,
-                  color: 'white',
-                  zIndex: 100,
-                  textDecoration: 'underline',
-                  display: 'flex',
-                  alignItems: 'center',
-                  my: 3,
-                  width: 'fit-content',
-                  textTransform: 'none',
-                  fontSize: [1, '16px', '18px'],
-                  fontWeight: 'normal',
-                }}>
-                Join Fallout
-                </Text>
-                <Box
-                  sx={{
-                    position:'relative',
-                    background: 'white',
-                    width: ['100%', '100%', '100%', '22vw'],
-                    minWidth: [null, null,'280px', null],
-                    maxWidth: [null, null, null,'480px'],
+                    <Box sx={{ display: 'flex', flexWrap: ['wrap', 'wrap', 'wrap', 'nowrap'] }}>
+                      <Button
+                        variant="ctaLg"
+                        as="a"
+                        {...({ href: "https://slack.hackclub.com" } as any)}
+                        my={[3, 3, 0]}
+                        mr={3}
+                        sx={{ transformOrigin: 'center left', whiteSpace: 'nowrap' }}
+                      >
+                        Join Hack Club
+                      </Button>
+                      <Text
+                        variant="eyebrow"
+                        as="h4"
+                        sx={{
+                          fontSize: [2, 2, 3],
+                          maxWidth: 'layout',
+                          my: 'auto',
+                          color: 'white',
+                          textShadow:
+                            'rgba(0, 0, 0, 1) 0 0 10px, rgba(0, 0, 0, 1) 0 0 10px, rgba(0, 0, 0, 0.5) 0 0 10px'
+                        }}
+                      >
+                        Or, check out our programs:
+                      </Text>
+                    </Box>
+                  </Box>
+                  <CTAS cards={ctaCards} />
 
-                    borderRadius:'extra',
-                    aspectRatio:'16/9',
-                    overflow: 'hidden',
-                    boxShadow: '0 4px 8px rgba(0, 0, 0, 0.125)',
-                    transition: 'transform .125s ease-in-out, box-shadow .125s ease-in-out',
-                    '&:hover': { transform: 'scale(1.0625)' },
-                    }}>
-                      <iframe 
-                        width="100%"
-                        height="100%" 
-                        src="https://www.youtube.com/embed/SrP2ZeNHm6s?si=orljJtYrC7EGSNzi&controls=0&modestbranding=1&rel=0" 
-                        title="YouTube video player" 
-                        frameBorder="0" 
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" 
-                        allowFullScreen>
-                      </iframe>
                 </Box>
-              </Box>   
+                <Box sx={{
+                  position: 'relative',
+                  marginLeft: [0, 0, 0, 'auto'],
+                  width: ['100%', '100%', '100%', 'auto'],
+                }}>
+                  <Text
+                    as="a"
+                    href="https://fallout.hackclub.com/?utm_source=cta"
+                    target="_blank"
+                    sx={{
+                      position: 'absolute',
+                      top: '100%',
+                      right: 0,
+                      color: 'white',
+                      zIndex: 100,
+                      textDecoration: 'underline',
+                      display: 'flex',
+                      alignItems: 'center',
+                      my: 3,
+                      width: 'fit-content',
+                      textTransform: 'none',
+                      fontSize: [1, '16px', '18px'],
+                      fontWeight: 'normal',
+                    }}>
+                    Join Fallout
+                  </Text>
+                  <Box
+                    sx={{
+                      position: 'relative',
+                      background: 'white',
+                      width: ['100%', '100%', '100%', '22vw'],
+                      minWidth: [null, null, '280px', null],
+                      maxWidth: [null, null, null, '480px'],
+
+                      borderRadius: 'extra',
+                      aspectRatio: '16/9',
+                      overflow: 'hidden',
+                      boxShadow: '0 4px 8px rgba(0, 0, 0, 0.125)',
+                      transition: 'transform .125s ease-in-out, box-shadow .125s ease-in-out',
+                      '&:hover': { transform: 'scale(1.0625)' },
+                    }}>
+                    <iframe
+                      width="100%"
+                      height="100%"
+                      src="https://www.youtube.com/embed/SrP2ZeNHm6s?si=orljJtYrC7EGSNzi&controls=0&modestbranding=1&rel=0"
+                      title="YouTube video player"
+                      frameBorder="0"
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin"
+                      allowFullScreen>
+                    </iframe>
+                  </Box>
+                </Box>
               </Box>
               <Button
                 sx={{
@@ -953,7 +953,7 @@ function Page({
                 >
                   builders
                 </Text>{' '}
-                from around the world 
+                from around the world
               </Text>
               <Text
                 variant="subtitle"


### PR DESCRIPTION
This reverts the padding between "welcome to hc" and "we are {} teen hackers" to what it was before, as it was adding a ton of random blank space between these two labels which are really part of the same introduction "phrase". 

Instead, the padding is now redistributed to underneath "check out some of our programs so that the alignment intended by the change in (#1926) is retained while resolving the slight awkwardness of where this space was placed.

Hero Before:

<img width="2005" height="1377" alt="image" src="https://github.com/user-attachments/assets/b2cc604c-2bc2-446d-a14a-97cefa0cdd06" />

Hero After:

<img width="2005" height="1377" alt="image" src="https://github.com/user-attachments/assets/fb07f436-0509-4377-a3ef-af5c8a55d95f" />

Before on another screen:

<img width="2005" height="1354" alt="image" src="https://github.com/user-attachments/assets/ec1cafee-e6de-49f2-acc3-f6b337a47ce8" />

And after:

<img width="2005" height="1378" alt="image" src="https://github.com/user-attachments/assets/c0f925d0-b4cd-49fa-ae8d-6bf527c04b4b" />





