### PR TITLE
Remove references to the in person hackathon-portion of Jackpot

### DIFF
--- a/components/index/cards/jackpot.tsx
+++ b/components/index/cards/jackpot.tsx
@@ -65,8 +65,7 @@ export default function Jackpot() {
             textAlign: 'left'
           }}
         >
-          Code for 65 hours and you’re invited to Las Vegas! (Or enjoy prizes that
-          YOU choose!)
+          Spend time coding and enjoy prizes that YOU choose!
         </Text>
         <Box
           as="a"

--- a/lib/cta.json
+++ b/lib/cta.json
@@ -51,7 +51,7 @@
         "logoScale": 1,
         "stickerImage": "https://cdn.hackclub.com/019d01dd-6b56-748a-8386-8f77bad07d46/meow.png",
         "stickerImageScale": 0.7,
-        "description": "Code for 65 hours and you’re invited to Las Vegas! (Or enjoy prizes that YOU choose!)",
+        "description": "Spend time coding and enjoy prizes that YOU choose!",
         "descriptionColor": "white",
         "buttonText": "JOIN NOW",
         "buttonColor": "#FAD10B",

--- a/public/carousel.json
+++ b/public/carousel.json
@@ -43,7 +43,7 @@
     "titleColor": "#FAD10B",
     "descriptionColor": "white",
     "title": "Jackpot",
-    "description": "Code for 65 hours and you're invited to Las Vegas! (Or enjoy prizes that YOU choose!)",
+    "description": "Spend time coding and enjoy prizes that YOU choose!",
     "img": "https://cdn.hackclub.com/019d01dd-6b56-748a-8386-8f77bad07d46/meow.png",
     "link": "https://jackpot.hackclub.com/?utm_source=site-carousel"
   },


### PR DESCRIPTION
See the banner of https://jackpot.hackclub.com/ or this bulletin [post](https://hackclub.slack.com/archives/C0ADEGZL5HD/p1774043876004439)

Changes description from

 `Code for 65 hours and you’re invited to Las Vegas! (Or enjoy prizes that YOU choose!)` 
---> 
`Spend time coding and enjoy prizes that YOU choose!)`