### PR TITLE
Revert Fallout Hero Video

### DIFF
--- a/lib/cta.json
+++ b/lib/cta.json
@@ -56,5 +56,18 @@
     "buttonText": "JOIN NOW",
     "buttonColor": "#FAD10B",
     "link": "https://jackpot.hackclub.com"
+  },
+    {
+    "title": "Fallout",
+    "logo": "https://cdn.hackclub.com/019cdfd0-6f09-7c8c-bd01-d0349e421c32/logo2.svg",
+    "background": "#39c9ff",
+    "logoScale": 1,
+    "stickerImage": "https://cdn.hackclub.com/019d36f6-2170-792f-9487-db64bce4cf65/koifish.webp",
+    "stickerImageScale": 0.7,
+    "description": "Build hardware projects, get build funding, and fly to a Shenzhen hackathon!",
+    "descriptionColor": "white",
+    "buttonText": "JOIN NOW",
+    "buttonColor": "#FAD10B",
+    "link": "https://fallout.hackclub.com"
   }
 ]

--- a/lib/cta.json
+++ b/lib/cta.json
@@ -57,7 +57,7 @@
     "buttonColor": "#FAD10B",
     "link": "https://jackpot.hackclub.com"
   },
-    {
+  {
     "title": "Fallout",
     "logo": "https://cdn.hackclub.com/019cdfd0-6f09-7c8c-bd01-d0349e421c32/logo2.svg",
     "background": "#39c9ff",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -528,64 +528,6 @@ function Page({
                   </Box>
                   <CTAS cards={ctaCards} />
                 </Box>
-                <Box
-                  sx={{
-                    position: 'relative',
-                    marginLeft: [0, 0, 0, 'auto'],
-                    width: ['100%', '100%', '100%', 'auto']
-                  }}
-                >
-                  <Text
-                    as="a"
-                    href="https://fallout.hackclub.com/?utm_source=cta"
-                    target="_blank"
-                    sx={{
-                      position: 'absolute',
-                      top: '100%',
-                      right: 0,
-                      color: 'white',
-                      zIndex: 100,
-                      textDecoration: 'underline',
-                      display: 'flex',
-                      alignItems: 'center',
-                      my: 3,
-                      width: 'fit-content',
-                      textTransform: 'none',
-                      fontSize: [1, '16px', '18px'],
-                      fontWeight: 'normal'
-                    }}
-                  >
-                    Join Fallout
-                  </Text>
-                  <Box
-                    sx={{
-                      position: 'relative',
-                      background: 'white',
-                      width: ['100%', '100%', '100%', '22vw'],
-                      minWidth: [null, null, '280px', null],
-                      maxWidth: [null, null, null, '480px'],
-
-                      borderRadius: 'extra',
-                      aspectRatio: '16/9',
-                      overflow: 'hidden',
-                      boxShadow: '0 4px 8px rgba(0, 0, 0, 0.125)',
-                      transition:
-                        'transform .125s ease-in-out, box-shadow .125s ease-in-out',
-                      '&:hover': { transform: 'scale(1.0625)' }
-                    }}
-                  >
-                    <iframe
-                      width="100%"
-                      height="100%"
-                      src="https://www.youtube.com/embed/SrP2ZeNHm6s?si=orljJtYrC7EGSNzi&controls=0&modestbranding=1&rel=0"
-                      title="YouTube video player"
-                      frameBorder="0"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                      referrerPolicy="strict-origin-when-cross-origin"
-                      allowFullScreen
-                    ></iframe>
-                  </Box>
-                </Box>
               </Box>
               <Button
                 sx={{

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -960,14 +960,10 @@ function Page({
               </Text>
             </Box>
             <Flavortown />
-            <Blueprint
-              blueprintData={blueprintData}
-              stars={stars.onboard.stargazerCount}
-            />
+            <Fallout />
             <Sleepover />
             <Stasis />
             <Jackpot />
-            <Fallout />
             <Scraps />
             <HackClubTheGame />
             <Milkyway />


### PR DESCRIPTION
This PR attempts to recognize a couple of things:

1. That the hero section fallout video was meant for a 2-week limited time period (endng today, March 28)
2. That As Blueprint is ending, Fallout is effectively its replacement and the new "flagship" hardware event)
  a. exhibit a: super similar concept (besides hackathon portion) incl. "provides funding for projects up to $350"
4. That people at HQ (incl. Zach) and myself are super hyped about it

What I've done in this PR is:
- gives Blueprint's big card space to Fallout
- remove's blueprint's big card (someone will probably be made abt this but it ends in 2 days :pf:)
- adds Fallout to the hero CTA rotation
  - <img width="1981" height="753" alt="image" src="https://github.com/user-attachments/assets/0b581254-f332-47d1-a1e8-48bf433e9de6" />
- remove the fallout hero video