### PR TITLE
Remove Zach Latta from Team Page

### DIFF
--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -103,13 +103,6 @@ export default function Team({ team }) {
               </Text>
               <Grid columns={[1, null, 2]} gap={5} mb={4}>
                 <BoardBox
-                  img="/team/zach.jpg"
-                  name="Zach Latta"
-                  teamRole="Founder"
-                  text="Zach dropped out of high school after his freshman year to work in the technology industry and had over 5 million people using his software by the time he turned 17. He founded Hack Club to build the program he wish he had in high school and has been awarded the Thiel Fellowship and Forbes 30 Under 30 for his work."
-                  email="zach"
-                />
-                <BoardBox
                   img="/team/christina.jpg"
                   name="Christina Asquith"
                   teamRole="Co-Founder and COO"


### PR DESCRIPTION
Implements proper changes for: https://github.com/hackclub/site/issues/1956

Removes non-team member adult from the team page.