### PR TITLE
fix "Received `false` for a non-boolean attribute `scrolled`"

### DIFF
--- a/components/flag.tsx
+++ b/components/flag.tsx
@@ -22,7 +22,7 @@ const waveFlagScaled = keyframes`
 `
 
 const scrolled = props =>
-  props.scrolled &&
+  props.scrolled ?
   css`
     transform: scale(0.875);
     height: 56px;
@@ -30,7 +30,7 @@ const scrolled = props =>
     &:focus {
       animation: ${waveFlagScaled} 0.5s linear infinite alternate;
     }
-  `
+  ` : undefined
 
 const Base = styled(Link)<{ uwu?: boolean }>`
   background-image: ${props =>

--- a/components/flag.tsx
+++ b/components/flag.tsx
@@ -22,15 +22,16 @@ const waveFlagScaled = keyframes`
 `
 
 const scrolled = props =>
-  props.scrolled ?
-  css`
-    transform: scale(0.875);
-    height: 56px;
-    &:hover,
-    &:focus {
-      animation: ${waveFlagScaled} 0.5s linear infinite alternate;
-    }
-  ` : undefined
+  props.scrolled
+    ? css`
+        transform: scale(0.875);
+        height: 56px;
+        &:hover,
+        &:focus {
+          animation: ${waveFlagScaled} 0.5s linear infinite alternate;
+        }
+      `
+    : undefined
 
 const Base = styled(Link)<{ uwu?: boolean }>`
   background-image: ${props =>


### PR DESCRIPTION
React is complaining with "Received `false` for a non-boolean attribute `scrolled`." because it wasn't using "condition ? value : undefined"